### PR TITLE
Remove field project._length and related code

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,6 @@ services:
       PGPASSWORD: docker
       PGUSER: docker
       TOGGLE_NEWSLETTER:
-      TOGGLE_USE_GEOMETRY_LENGTH:
     command: bash -c "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
     volumes:
       - .:/code

--- a/fixmyapp/models.py
+++ b/fixmyapp/models.py
@@ -415,7 +415,6 @@ class Project(BaseModel):
         _('short description'), blank=True, null=True, max_length=200
     )
     geometry = models.GeometryField(_('geometry'), blank=True, null=True)
-    _length = models.IntegerField(_('length'), db_column='length', blank=True, null=True)
     category = models.CharField(
         _('category'),
         blank=True,
@@ -476,10 +475,9 @@ class Project(BaseModel):
             return self.geometry.point_on_surface
 
     def length(self):
-        if settings.TOGGLE_USE_GEOMETRY_LENGTH and self.geometry:
+        if self.geometry:
             return self.geometry.transform(self.TRANSFORM_EPSG_3035, clone=True).length
-        elif not settings.TOGGLE_USE_GEOMETRY_LENGTH:
-            return self._length
+        return None
 
     def __str__(self):
         return self.project_key

--- a/fixmydjango/settings.py
+++ b/fixmydjango/settings.py
@@ -305,4 +305,3 @@ DATABASES['default']['ENGINE'] = 'django.contrib.gis.db.backends.postgis'
 # Feature-Toggles
 
 TOGGLE_NEWSLETTER = bool(os.getenv('TOGGLE_NEWSLETTER', False))
-TOGGLE_USE_GEOMETRY_LENGTH = bool(os.getenv('TOGGLE_USE_GEOMETRY_LENGTH', False))


### PR DESCRIPTION
Removes the obsolete field `project._length` and related code / features. Project length is then always computed from the project geometry and cannot be set manually in the admin panel anymore.

Fixes #247 

## Type of change

Please delete options that are not relevant.

- Paying off debt
- Breaking change (fix or feature that would cause existing functionality
  to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
