### PR TITLE
Don't attempt donwloading directory reference

### DIFF
--- a/fixmyapp/management/commands/downloadfiles.py
+++ b/fixmyapp/management/commands/downloadfiles.py
@@ -6,11 +6,7 @@ class Command(BaseCommand):
     help = 'Download contents of storage bucket to /tmp'
 
     def add_arguments(self, parser):
-        parser.add_argument(
-            'dir',
-            type=str,
-            help='A directory in the bucket'
-        )
+        parser.add_argument('dir', type=str, help='A directory in the bucket')
 
     def handle(self, *args, **options):
         if not options['dir'].endswith('/'):
@@ -25,18 +21,18 @@ class Command(BaseCommand):
 
         files = default_storage.listdir(directory)[1]
 
-        if len([f for f in files if f != '']) == 0:
+        valid_files = [f for f in files if f != '' and f != '.']
+
+        if len(valid_files) == 0:
             raise CommandError('The directory {} is empty'.format(directory))
 
-        for file in (f for f in files if f != ''):
+        for file in valid_files:
             target = '/tmp/' + file
             key = directory + file
             default_storage.bucket.download_file(key, target)
             if options['verbosity'] > 1:
                 self.stdout.write(
-                    'Successfully downloaded "{}" to "{}".'.format(
-                        key, target
-                    )
+                    'Successfully downloaded "{}" to "{}".'.format(key, target)
                 )
 
         if options['verbosity'] > 0:


### PR DESCRIPTION
Filter out reference to directory (`.`) before attempting to download files from S3 directory.

Fixes #347 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `python manage.py downloadfiles Data`

