### PR TITLE
Upgrade django extra fields

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ debugpy==1.2.0
 django-anymail==3.0
 django-auto-prefetching==0.1.8
 django-cors-headers==3.2.1
-django-extra-fields==2.0.3
 django-heroku==0.3.1
 django-markdownx==3.0.1
 django-nose==1.4.6
@@ -16,6 +15,7 @@ djangorestframework-gis==0.16
 djangorestframework-simplejwt==4.3.0
 djangorestframework==3.12.2
 djoser==2.0.3
+drf-extra-fields==3.0.3
 flake8==3.7.8
 gunicorn==19.7.0
 mailjet-rest==1.3.4


### PR DESCRIPTION
The library was renamed from django-extra-fields to drf-extra-fields