### PR TITLE
Stations API: Change photos array to include descriptions without photos

### DIFF
--- a/fahrradparken/fixtures/survey_station.json
+++ b/fahrradparken/fixtures/survey_station.json
@@ -13,6 +13,7 @@
             "annoyance_custom": "Die Leute drehen immer meinen Sattel um.",
             "requested_location": "Westseite",
             "photo": "",
+            "is_photo_published": false,
             "photo_terms_accepted": null,
             "photo_description": null
         }
@@ -31,15 +32,16 @@
             "annoyance_custom": "",
             "requested_location": "Ausgang Stadt",
             "photo": "",
+            "is_photo_published": false,
             "photo_terms_accepted": null,
             "photo_description": null
         }
     },
     {
         "model": "fahrradparken.surveystation",
-        "pk": 2,
+        "pk": 3,
         "fields": {
-            "session": "ba86d361-87a3-4e14-bd3a-fcf9003f7dd8",
+            "session": "06f2fe03-ed58-45ec-b55f-df5ea6fa8f30",
             "created_date": "2021-08-18T12:22:34.615Z",
             "modified_date": "2021-08-18T12:22:34.615Z",
             "station": 2,
@@ -49,8 +51,85 @@
             "annoyance_custom": "",
             "requested_location": "Ausgang Stadt",
             "photo": "",
+            "is_photo_published": false,
             "photo_terms_accepted": null,
             "photo_description": null
+        }
+    },
+    {
+        "model": "fahrradparken.surveystation",
+        "pk": 4,
+        "fields": {
+            "session": "1721b6c7-cbdc-4a48-8a78-b63ab3da78d0",
+            "created_date": "2021-08-18T12:22:34.615Z",
+            "modified_date": "2021-08-18T12:22:34.615Z",
+            "station": 2,
+            "survey_version": 1,
+            "npr": 6,
+            "annoyances": "3",
+            "annoyance_custom": "",
+            "requested_location": "Photo uploaded and moderated, no description",
+            "photo": "https://example.com/location.jpg",
+            "is_photo_published": true,
+            "photo_terms_accepted": "2021-08-18T12:22:34.615Z",
+            "photo_description": null
+        }
+    },
+    {
+        "model": "fahrradparken.surveystation",
+        "pk": 5,
+        "fields": {
+            "session": "30c099bc-a087-4565-bba8-e1d36e2d0f1b",
+            "created_date": "2021-08-18T12:22:34.615Z",
+            "modified_date": "2021-08-18T12:22:34.615Z",
+            "station": 2,
+            "survey_version": 1,
+            "npr": 6,
+            "annoyances": "3",
+            "annoyance_custom": "",
+            "requested_location": "Photo uploaded and moderated, with description",
+            "photo": "https://example.com/",
+            "is_photo_published": true,
+            "photo_terms_accepted": "2021-08-18T12:22:34.615Z",
+            "photo_description": "Location description"
+        }
+    },
+    {
+        "model": "fahrradparken.surveystation",
+        "pk": 6,
+        "fields": {
+            "session": "8f5d846a-9233-4273-be89-8bb86b8b3c45",
+            "created_date": "2021-08-18T12:22:34.615Z",
+            "modified_date": "2021-08-18T12:22:34.615Z",
+            "station": 2,
+            "survey_version": 1,
+            "npr": 6,
+            "annoyances": "3",
+            "annoyance_custom": "",
+            "requested_location": "Photo uploaded not moderated yet, no description (does not show in API)",
+            "photo": null,
+            "is_photo_published": false,
+            "photo_terms_accepted": "2021-08-18T12:22:34.615Z",
+            "photo_description": null
+        }
+    },
+    {
+        "model": "fahrradparken.surveystation",
+        "pk": 6,
+        "fields": {
+            "session": "dfb8f274-f0f7-4419-b6b1-a446c7eaf5a3",
+            "created_date": "2021-08-18T12:22:34.615Z",
+            "modified_date": "2021-08-18T12:22:34.615Z",
+            "station": 2,
+            "survey_version": 1,
+            "npr": 6,
+            "annoyances": "3",
+            "annoyance_custom": "",
+            "requested_location": "Photo uploaded not moderated yet, with description",
+            "photo": null,
+            "is_photo_published": false,
+            "photo_terms_accepted": "2021-08-18T12:22:34.615Z",
+            "photo_description": "Location description"
         }
     }
 ]

--- a/fahrradparken/tests.py
+++ b/fahrradparken/tests.py
@@ -162,8 +162,7 @@ class StationTest(TestCase):
         self.assertEqual(data['features'][0]['geometry']['type'], 'Point')
 
     def test_get_detail(self):
-        station = Station.objects.all()[0]
-        url = f'/api/fahrradparken/stations/{station.id}'
+        url = f'/api/fahrradparken/stations/2'
         response = self.client.get(url, content_type='application/json')
         self.assertEqual(response.status_code, 200, response.content)
         props = response.json()['properties']


### PR DESCRIPTION
The survey UI will be changed to ask for a location description without adding a picture (which is already possible). The output UI will change by showing location descriptions without a picture as a quote.

Relevant API is at https://api.fixmycity.de/api/fahrradparken/stations/1