### PR TITLE
Refactor open-api generation.

### DIFF
--- a/fahrradparken/models.py
+++ b/fahrradparken/models.py
@@ -49,7 +49,7 @@ class Station(BaseModel):
     ]
 
     id = models.IntegerField(_('station number'), primary_key=True)
-    name = models.CharField(_('name'), max_length=255)
+    name = models.CharField(_('name'), max_length=255, help_text="Name der Haltestelle")
     location = models.PointField(_('geometry'), srid=4326)
     travellers = models.IntegerField(_('traveller count'), choices=TRAVELLERS_CHOICES)
     post_code = models.CharField(_('post code'), max_length=16, blank=True, null=True)

--- a/fahrradparken/openapi.py
+++ b/fahrradparken/openapi.py
@@ -1,0 +1,15 @@
+from rest_framework.schemas.openapi import SchemaGenerator
+
+# class to modify the generated schema s.t. there are only get methods
+class ReadOnlySchemaGenerator(SchemaGenerator):
+    def get_schema(self, *args, **kwargs):
+        schema = super().get_schema(*args, **kwargs)
+        paths = schema['paths']
+        print(paths)
+        ro_paths = {}
+        for p in paths:
+            if 'get' in paths[p]:
+                ro_paths[p] = {'get': paths[p]['get']}
+        print(ro_paths)
+        schema['paths'] = ro_paths
+        return schema

--- a/fahrradparken/openapi.py
+++ b/fahrradparken/openapi.py
@@ -5,11 +5,9 @@ class ReadOnlySchemaGenerator(SchemaGenerator):
     def get_schema(self, *args, **kwargs):
         schema = super().get_schema(*args, **kwargs)
         paths = schema['paths']
-        print(paths)
         ro_paths = {}
         for p in paths:
             if 'get' in paths[p]:
                 ro_paths[p] = {'get': paths[p]['get']}
-        print(ro_paths)
         schema['paths'] = ro_paths
         return schema

--- a/fahrradparken/serializers.py
+++ b/fahrradparken/serializers.py
@@ -5,6 +5,7 @@ import json
 from django.conf import settings
 from drf_extra_fields.fields import HybridImageField
 from rest_framework import serializers
+from rest_framework_gis.serializers import GeoFeatureModelSerializer
 
 from .models import (
     EventSignup,
@@ -158,7 +159,7 @@ class ParkingFacilitySerializer(serializers.ModelSerializer):
         return super().update(instance, validated_data)
 
 
-class StationSerializer(serializers.ModelSerializer):
+class StationSerializer(GeoFeatureModelSerializer):
     annoyances_custom = serializers.ReadOnlyField()
     annoyances = serializers.ReadOnlyField()
     net_promoter_score = serializers.ReadOnlyField()
@@ -168,18 +169,11 @@ class StationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Station
-        exclude = ('created_date', 'modified_date', 'location')
-
-    def to_representation(self, instance):
-        props = super().to_representation(instance)
-        return {
-            'type': 'Feature',
-            'geometry': json.loads(instance.location.json),
-            'properties': props,
-        }
+        exclude = ('created_date', 'modified_date')
+        geo_field = 'location'
 
 
-class StaticStationSerializer(serializers.ModelSerializer):
+class StaticStationSerializer(GeoFeatureModelSerializer):
     """This serializer doesn't output dynamic user data."""
 
     class Meta:
@@ -193,14 +187,7 @@ class StaticStationSerializer(serializers.ModelSerializer):
             'is_long_distance',
             'is_light_rail',
         )
-
-    def to_representation(self, instance):
-        props = super().to_representation(instance)
-        return {
-            'type': 'Feature',
-            'geometry': json.loads(instance.location.json),
-            'properties': props,
-        }
+        geo_field = 'location'
 
 
 class SurveyStationSerializer(serializers.ModelSerializer):

--- a/fahrradparken/urls.py
+++ b/fahrradparken/urls.py
@@ -79,20 +79,24 @@ privateurls = [
         'uuid/<uuid:session>/bicycle-usage-survey',
         CheckPreviousBicycleSurvey.as_view(),
         name='fahrradparken-previous-bicycle-survey-by-session',
-    )
-    ]
-
-urlpatterns = publicurls + privateurls + [
-    path(
-        'openapi',
-        get_schema_view(
-            title="The Fahrradparken-API documentation",
-            description="The API documentation for radparken.info",
-            version="1.0.0",
-            patterns=publicurls,
-            url='/api/fahrradparken',
-            generator_class=ReadOnlySchemaGenerator,
-        ),
-        name='openapi',
-    )
+    ),
 ]
+
+urlpatterns = (
+    [
+        path(
+            'openapi',
+            get_schema_view(
+                title="The Fahrradparken-API documentation",
+                description="The API documentation for radparken.info",
+                version="1.0.0",
+                patterns=publicurls,
+                url='/api/fahrradparken',
+                generator_class=ReadOnlySchemaGenerator,
+            ),
+            name='openapi',
+        )
+    ]
+    + publicurls
+    + privateurls
+)

--- a/fahrradparken/views.py
+++ b/fahrradparken/views.py
@@ -6,7 +6,12 @@ from django.conf import settings
 from django.db.models import Count, Sum
 from django.http.response import Http404
 from rest_framework import permissions, status, filters
-from rest_framework.generics import ListCreateAPIView, RetrieveUpdateAPIView, RetrieveAPIView, ListAPIView
+from rest_framework.generics import (
+    ListCreateAPIView,
+    RetrieveUpdateAPIView,
+    RetrieveAPIView,
+    ListAPIView,
+)
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.response import Response

--- a/fahrradparken/views.py
+++ b/fahrradparken/views.py
@@ -152,17 +152,10 @@ class StationList(ListAPIView):
     ordering = ['-travellers', 'community', '-is_long_distance', 'name']
     serializer_class = StaticStationSerializer
 
-    def list(self, request):
-        """Searchable station listing as GeoJSON.
-
-        Use the `search` URL parameter to filter by station name and community."""
-        queryset = self.get_queryset()
-        filtered_queryset = self.filter_queryset(queryset)
-        features = StaticStationSerializer(filtered_queryset, many=True)
-        return Response(data={'type': 'FeatureCollection', 'features': features.data})
-
-
 class StationView(RetrieveAPIView):
+    """
+    Returns the station with the specified `id` in the system.
+    """
     permission_classes = (permissions.AllowAny,)
     queryset = Station.objects.prefetch_related('survey_responses')
     serializer_class = StationSerializer

--- a/fahrradparken/views.py
+++ b/fahrradparken/views.py
@@ -152,10 +152,12 @@ class StationList(ListAPIView):
     ordering = ['-travellers', 'community', '-is_long_distance', 'name']
     serializer_class = StaticStationSerializer
 
+
 class StationView(RetrieveAPIView):
     """
     Returns the station with the specified `id` in the system.
     """
+
     permission_classes = (permissions.AllowAny,)
     queryset = Station.objects.prefetch_related('survey_responses')
     serializer_class = StationSerializer

--- a/fahrradparken/views.py
+++ b/fahrradparken/views.py
@@ -5,8 +5,8 @@ from datetime import datetime
 from django.conf import settings
 from django.db.models import Count, Sum
 from django.http.response import Http404
-from rest_framework import permissions, status, generics, filters
-from rest_framework.generics import ListCreateAPIView, RetrieveUpdateAPIView, RetrieveAPIView
+from rest_framework import permissions, status, filters
+from rest_framework.generics import ListCreateAPIView, RetrieveUpdateAPIView, RetrieveAPIView, ListAPIView
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.response import Response
@@ -140,7 +140,7 @@ class SurveyInfoView(APIView):
         )
 
 
-class StationList(generics.ListAPIView):
+class StationList(ListAPIView):
     queryset = Station.objects.all()
     filter_backends = [filters.SearchFilter, filters.OrderingFilter]
     search_fields = ['name', 'community']
@@ -178,7 +178,7 @@ class SurveyStationView(APIView):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
-class StationSurveysByUUID(generics.ListAPIView):
+class StationSurveysByUUID(ListAPIView):
     serializer_class = SurveyStationShortSerializer
 
     def get_queryset(self):
@@ -236,7 +236,7 @@ class PhotoUploadView(APIView):
         return Response({'path': s3_key})
 
 
-class RawStationSurveyListing(generics.ListAPIView):
+class RawStationSurveyListing(ListAPIView):
     queryset = SurveyStation.objects.all()
     filter_backends = [filters.OrderingFilter]
     ordering = ['station']
@@ -249,7 +249,7 @@ class RawStationSurveyListing(generics.ListAPIView):
         return Response(data=serialized.data)
 
 
-class RawBicycleUsageSurveyListing(generics.ListAPIView):
+class RawBicycleUsageSurveyListing(ListAPIView):
     queryset = SurveyBicycleUsage.objects.all()
     serializer_class = SurveyBicycleUsageSerializer
 

--- a/fahrradparken/views.py
+++ b/fahrradparken/views.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.db.models import Count, Sum
 from django.http.response import Http404
 from rest_framework import permissions, status, generics, filters
-from rest_framework.generics import ListCreateAPIView, RetrieveUpdateAPIView
+from rest_framework.generics import ListCreateAPIView, RetrieveUpdateAPIView, RetrieveAPIView
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.response import Response
@@ -157,19 +157,10 @@ class StationList(generics.ListAPIView):
         return Response(data={'type': 'FeatureCollection', 'features': features.data})
 
 
-class StationView(APIView):
+class StationView(RetrieveAPIView):
     permission_classes = (permissions.AllowAny,)
-
-    def get_object(self, pk):
-        try:
-            return Station.objects.prefetch_related('survey_responses').get(pk=pk)
-        except Station.DoesNotExist:
-            raise Http404
-
-    def get(self, request, pk):
-        station = self.get_object(pk)
-        serializer = StationSerializer(station, context={'request': request})
-        return Response(serializer.data)
+    queryset = Station.objects.prefetch_related('survey_responses')
+    serializer_class = StationSerializer
 
 
 class SurveyStationView(APIView):

--- a/fixmydjango/settings.py
+++ b/fixmydjango/settings.py
@@ -80,8 +80,8 @@ INSTALLED_APPS = [
     'djoser',
     'fixmyapp.apps.FixmyappConfig',
     'markdownx',
-    'rest_framework_gis',
     'rest_framework',
+    'rest_framework_gis',
     'reversion',
     'survey',
     'reports',
@@ -259,6 +259,7 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
     ],
     'DEFAULT_RENDERER_CLASSES': ['rest_framework.renderers.JSONRenderer'],
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework_gis.schema.GeoFeatureAutoSchema',
 }
 
 


### PR DESCRIPTION
This PR refactors the open-api  generation for `/api/fahrradparken` and applies the following changes:
- excludes the `/api/fahrradparken/uuid/*` routes from the open api docs
- rewrite `/api/fahrradparken/stations/{id}` as a `RetrievAPIView` class

Related [PR](https://github.com/FixMyBerlin/fixmy.fahrradparken/pull/288) in [fixmy.fahrradparken](https://github.com/FixMyBerlin/fixmy.fahrradparken).